### PR TITLE
making the cordova plugins add call more explicit that it's a CLI thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A sample application that demonstrates a lightweight approach to integrate with 
 
 2. Add the inappbrowser plugin to your project
 
-   cordova plugins add org.apache.cordova.inappbrowser
+  ```
+  $ cordova plugins add org.apache.cordova.inappbrowser
+  ```
 
 3. Replace the www folder of the Ionic project with the www folder in this repository
 


### PR DESCRIPTION
Just a small tweak to the README to have it be clearer that the 2nd step uses the CLI for cordova.

Great example app and thanks for creating/sharing!! 
